### PR TITLE
Fixes invalid syntax with latest YAML parser

### DIFF
--- a/theme.yaml
+++ b/theme.yaml
@@ -125,7 +125,7 @@ form:
 
                         href:
                             label: URL
-                            comment: The full URL to your profile. It is recommended to begin the URL with two forward slash. Eg: //twitter.com/krisawzm
+                            comment: "The full URL to your profile. It is recommended to begin the URL with two forward slash. Eg: //twitter.com/krisawzm"
 
 
             #


### PR DESCRIPTION
Error message:
A colon cannot be used in an unquoted mapping value at line 126 (near "comment: The full URL to your profile. It is recommended to begin the URL with two forward slash. Eg: //twitter.com/krisawzm").
